### PR TITLE
Fix ftdetect

### DIFF
--- a/ftdetect/irssi.vim
+++ b/ftdetect/irssi.vim
@@ -1,9 +1,4 @@
-
-function! s:detectIrssiFile()
-	let _dirname = expand('%:p:h:t')
-	if _dirname == '.irssi' || _dirname == 'irssi'
-		setfiletype irssi
-	endif
-endfunction
-
-autocmd BufNewFile,BufRead config call s:detectIrssiFile()
+augroup irssi_ftdetect
+  au!
+  au BufRead,BufNewFile *irssi/config set ft=irssi
+augroup END


### PR DESCRIPTION
see https://github.com/PotatoesMaster/i3-vim-syntax/blob/master/ftdetect/i3.vim

I think we should use augroup, add `au!` to make sure clean up the augroup.
BTW  the config file is not only in `.irssi` dir, my config is `~/DotFiles/irssi/config`, and I use `ln -s`
